### PR TITLE
Removing reference to hardcoded name for Controller host

### DIFF
--- a/lib/admin_openrc.sh
+++ b/lib/admin_openrc.sh
@@ -1,11 +1,24 @@
-echo "Running: $0 $@"
-source $(dirname $0)/config-parameters.sh
+if [ "$controller_host_name" == "" ]
+then
+	echo "Controller Host Name Environment variable is blank. Checking command line argument."
+	if [ "$1" == "" ]
+	then
+		echo "Controller Host Name Command line argument is blank. Using default name for Controller."
+		final_controller_host_name="controller"
+	else
+		final_controller_host_name=$1
+	fi	
+else
+	final_controller_host_name=$controller_host_name
+fi
 
+echo "Final Controller Host Name: "$final_controller_host_name
+	
 export OS_PROJECT_DOMAIN_NAME=default
 export OS_USER_DOMAIN_NAME=default
 export OS_PROJECT_NAME=admin
 export OS_USERNAME=admin
 export OS_PASSWORD=password
-export OS_AUTH_URL=http://$controller_host_name:35357/v3
+export OS_AUTH_URL=http://$final_controller_host_name:35357/v3
 export OS_IDENTITY_API_VERSION=3
 export OS_IMAGE_API_VERSION=2

--- a/lib/admin_openrc.sh
+++ b/lib/admin_openrc.sh
@@ -1,8 +1,11 @@
+echo "Running: $0 $@"
+source $(dirname $0)/config-parameters.sh
+
 export OS_PROJECT_DOMAIN_NAME=default
 export OS_USER_DOMAIN_NAME=default
 export OS_PROJECT_NAME=admin
 export OS_USERNAME=admin
 export OS_PASSWORD=password
-export OS_AUTH_URL=http://controller:35357/v3
+export OS_AUTH_URL=http://$controller_host_name:35357/v3
 export OS_IDENTITY_API_VERSION=3
 export OS_IMAGE_API_VERSION=2

--- a/lib/configure-nova.sh
+++ b/lib/configure-nova.sh
@@ -79,7 +79,7 @@ elif [ "$1" == "compute" ]
 		crudini --set /etc/nova/nova.conf vnc novncproxy_base_url http://$controller_ip:6080/vnc_auto.html
 fi
 
-crudini --set /etc/nova/nova.conf glance api_servers http://controller:9292
+crudini --set /etc/nova/nova.conf glance api_servers http://$2:9292
 crudini --set /etc/nova/nova.conf oslo_concurrency lock_path /var/lib/nova/tmp
 crudini --set /etc/nova/nova.conf DEFAULT verbose True
 echo_and_sleep "Updated NOVA Configuration File" 2


### PR DESCRIPTION
In couple of place the host name for Controller was hardcoded as "controller".
In nova.conf the glance_api_servers now uses the command line parameter.
In admin_openrc.sh, use the environment variable (used during config scripts) OR use command line parameter OR fall back to default of "controller"